### PR TITLE
feat: add request_faucet_funds and address_reputation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ Example query to Claude:
 
 > "Deploy a simple ERC20 token contract for me."
 
+### check-address-reputation
+
+Checks the reputation of an address.
+
+Parameters:
+
+- `address`: The Ethereum address to check
+
+Example query to Claude:
+
+> "What's the reputation of 0x1234567890abcdef1234567890abcdef12345678?"
+
 ### get_morpho_vaults
 
 Gets the vaults for a given asset on Morpho.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ ALCHEMY_API_KEY=your_alchemy_api_key
 # OpenRouter API Key (optional for buying OpenRouter credits)
 # You can obtain this from https://openrouter.ai/keys
 OPENROUTER_API_KEY=your_openrouter_api_key
+
+# Chain ID (optional for Base Sepolia testnet)
+# Use 84532 for Base Sepolia testnet
+# You do not have to include this if you want to use Base Mainnet
+CHAIN_ID=your_chain_id
 ```
 
 ## Testing
@@ -192,7 +197,8 @@ You can easily access this file via the Claude Desktop app by navigating to Clau
            "SEED_PHRASE": "your seed phrase here",
            "COINBASE_PROJECT_ID": "your_project_id",
            "ALCHEMY_API_KEY": "your_alchemy_api_key",
-           "OPENROUTER_API_KEY": "your_openrouter_api_key"
+           "OPENROUTER_API_KEY": "your_openrouter_api_key",
+           "CHAIN_ID": "optional_for_base_sepolia_testnet"
          },
          "disabled": false,
          "autoApprove": []

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
   AgentKit,
   basenameActionProvider,
+  cdpApiActionProvider,
   cdpWalletActionProvider,
   CdpWalletProvider,
   morphoActionProvider,
@@ -74,6 +75,10 @@ export async function main() {
       morphoActionProvider(),
       walletActionProvider(),
       cdpWalletActionProvider({
+        apiKeyName,
+        apiKeyPrivateKey: privateKey,
+      }),
+      cdpApiActionProvider({
         apiKeyName,
         apiKeyPrivateKey: privateKey,
       }),


### PR DESCRIPTION
## Description

The `get-testnet-eth` tool from the examples.md does not seem to work.
So I added `cdpApiActionProvider` in `actionProviders` for `AgentKit`.

This would expose two tools from `cdpApiActionProvider`
- cdpApiActionProvider_request_faucet_funds
- cdpApiActionProvider_address_reputation

I also updated the documentation
- let people know they can specify `CHAIN_ID` env var to use Base Sepolia testnet
- add `check-address-reputation` to `Available Tools`

Fixes # (issue)

The `get-testnet-eth` tool from the examples.md does not seem to work.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Tested with Claude Desktop.

Asked the following questions on both Base Mainnet and Base Sepolia testnet.
- I need some testnet ETH for development.
- What's the reputation of my address?
- What's the reputation of address 0x2c158264341bBa997cA70bFC4AEf242606D3E53E?

See chat history for Base Mainnet: https://claude.ai/share/8e17bfbf-e46c-487b-938a-9f8f7912c18b
See chat history for Base Sepolia: https://claude.ai/share/dde6c440-8767-4f30-853d-48f286620180

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots (if appropriate):
